### PR TITLE
fix like may not saved error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 .cxx
 local.properties
 files
+app/release/baselineProfiles/

--- a/app/src/main/java/com/lizongying/mytv0/MainActivity.kt
+++ b/app/src/main/java/com/lizongying/mytv0/MainActivity.kt
@@ -205,7 +205,7 @@ class MainActivity : FragmentActivity() {
             }
 
             tvModel.like.observe(this) { _ ->
-                if (tvModel.like.value != null) {
+                if (tvModel.like.value != null && tvModel.tv.id != -1) {
                     val liked = tvModel.like.value as Boolean
                     if (liked) {
                         TVList.groupModel.getTVListModel(0)?.replaceTVModel(tvModel)

--- a/app/src/main/java/com/lizongying/mytv0/models/TV.kt
+++ b/app/src/main/java/com/lizongying/mytv0/models/TV.kt
@@ -3,7 +3,7 @@ package com.lizongying.mytv0.models
 import java.io.Serializable
 
 data class TV(
-    var id: Int = 0,
+    var id: Int = -1,
     var name: String = "",
     var title: String = "",
     var description: String? = null,

--- a/app/src/main/java/com/lizongying/mytv0/models/TVList.kt
+++ b/app/src/main/java/com/lizongying/mytv0/models/TVList.kt
@@ -223,7 +223,7 @@ object TVList {
                         val uris =
                             if (index + 1 < lines.size) listOf(lines[index + 1].trim()) else emptyList()
                         val tv = TV(
-                            0,
+                            -1,
                             name ?: "",
                             title,
                             "",
@@ -257,7 +257,7 @@ object TVList {
                             val title = arr.first().trim()
                             val uris = arr.drop(1)
                             val tv = TV(
-                                0,
+                                -1,
                                 "",
                                 title,
                                 "",
@@ -296,6 +296,7 @@ object TVList {
             val tvListModel = TVListModel(k, groupIndex)
             for ((listIndex, v1) in v.withIndex()) {
                 v1.tv.id = id
+                v1.setLike(SP.getLike(id))
                 v1.groupIndex = groupIndex
                 v1.listIndex = listIndex
                 tvListModel.addTVModel(v1)


### PR DESCRIPTION
收藏的结果在app重启的时候会被覆盖。 

因为 TV初始化的时候所有的id被赋值为0，而0是一个有效的id，所以导致app重启的时候，每个tv的like都被设置成了id为0的like，又因为有observe的存在导致这个结果被写入配置。

可以将tv的id初始化为-1，并且在observe函数中检测如果id为-1暂时不更改like，在给tv的id赋值以后更新like。