### PR TITLE
[fix] 100% fail when setting proxy

### DIFF
--- a/app/src/main/res/raw/index.html
+++ b/app/src/main/res/raw/index.html
@@ -333,7 +333,7 @@
         if (proxy && (!proxy.startsWith('http') && !proxy.startsWith('socks'))) {
             proxy = 'http://' + proxy;
         }
-        if (proxy && (!proxy.startsWith('http') || !proxy.startsWith('socks'))) {
+        if (proxy && (!proxy.startsWith('http') && !proxy.startsWith('socks'))) {
             alert(`無效的地址${proxy}`);
             return;
         }


### PR DESCRIPTION
test script:
```js
function test(proxy) {
    if (proxy && (!proxy.startsWith('http') && !proxy.startsWith('socks'))) {
        proxy = 'http://' + proxy;
    }
    if (proxy && (!proxy.startsWith('http') || !proxy.startsWith('socks'))) {
        console.log(`無效的地址${proxy}`);
        return;
    }
    console.log(`${proxy} ok`);
}

test('http://127.0.0.1:8888/');
test('socks://127.0.0.1:8888/');
test('https://127.0.0.1:8888/');
test('xxx://127.0.0.1:8888/');
test('127.0.0.1:8888/');
```

```shell
# node test.js
無效的地址http://127.0.0.1:8888/
無效的地址socks://127.0.0.1:8888/
無效的地址https://127.0.0.1:8888/
無效的地址http://xxx://127.0.0.1:8888/
無效的地址http://127.0.0.1:8888/
```